### PR TITLE
update php_codesniffer to match current version used by terminus

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.8.1",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
                 "shasum": ""
             },
             "require": {
@@ -83,7 +83,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-03-01T22:17:45+00:00"
+            "time": "2017-05-22T02:43:20+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
After installing this plugin, I get the following error trying to use it:

```
  [Pantheon\Terminus\Exceptions\TerminusException]                                                                                                        
  The plugin pantheon-systems/terminus-rsync-plugin has installed the project squizlabs/php_codesniffer: 2.8.1, but Terminus has installed squizlabs/php  
  _codesniffer: 2.9.1. To resolve this, try running 'composer update' in both the plugin directory, and the terminus directory.                           
```

Following the instruction in the error message (`composer update`) does indeed fix it.                                                                                                                                                    
