### PR TITLE
put paths in quotes to preserve spaces etc

### DIFF
--- a/src/Commands/RsyncCommand.php
+++ b/src/Commands/RsyncCommand.php
@@ -93,7 +93,7 @@ class RsyncCommand extends TerminusCommand implements SiteAwareInterface
         }
 
         $this->log()->notice('Running {cmd}', ['cmd' => "rsync $rsyncOptionString $src $dest"]);
-        $this->passthru("rsync $rsyncOptionString --ipv4 --exclude=.git -e 'ssh -p 2222' $src $dest ");
+        $this->passthru("rsync $rsyncOptionString --ipv4 --exclude=.git -e 'ssh -p 2222' '$src' '$dest' ");
     }
 
     protected function passthru($command)


### PR DESCRIPTION
Trying to rsync with a space or parentheses in either the src or dest paths generates an error, e.g.

```
terminus rsync -- ~/Dropbox\ \(Personal\)/README.txt mysite.dev:files/
…
sh: -c: line 0: syntax error near unexpected token `('
```

or

```
terminus rsync -- ~/README.txt mysite.dev:files/untitled\ folder/`
…
rsync: link_stat "/Users/brandt/Projects/mysite/web/dev.fff58070-166a-485f-a158-cb401d828423@appserver.dev.fff58070-166a-485f-a158-cb401d828423.drush.in:files/untitled" failed: No such file or directory (2)
```

This patch fixes it.