### PR TITLE
include "-c" option to use checksum when determining which files to copy

### DIFF
--- a/src/Commands/RsyncCommand.php
+++ b/src/Commands/RsyncCommand.php
@@ -85,7 +85,7 @@ class RsyncCommand extends TerminusCommand implements SiteAwareInterface
         // in any mode options (e.g. '-r'), then add in the default.
         $rsyncOptionString = implode(' ', $rsyncOptions);
         if (!preg_match('/(^| )-[^-]/', $rsyncOptionString)) {
-            $rsyncOptionString = "-rlIpz $rsyncOptionString";
+            $rsyncOptionString = "-rlIpzc $rsyncOptionString";
         }
         // Add in a tmp-dir option if one was not already specified
         if (!empty($tmpdir) && !preg_match('/(^| )--temp-dir/', $rsyncOptionString)) {


### PR DESCRIPTION
The [rsync docs](https://pantheon.io/docs/rsync-and-sftp/#rsync) were recently updated to recommend including the `--checksum` option. This PR adds that option to the default set of rsync options.