### PR TITLE
Fix comments

### DIFF
--- a/src/Commands/RsyncCommand.php
+++ b/src/Commands/RsyncCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This command will manage secrets on a Pantheon site.
+ * This command will run rsync commands on a Pantheon site.
  *
  * See README.md for usage information.
  */
@@ -15,7 +15,7 @@ use Pantheon\Terminus\Site\SiteAwareTrait;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * Manage secrets on a Pantheon instance
+ * Run rsync commands on a Pantheon instance
  */
 class RsyncCommand extends TerminusCommand implements SiteAwareInterface
 {


### PR DESCRIPTION
I *think* these comments are possibly unchanged from the secrets plugin ([ref](https://github.com/pantheon-systems/terminus-secrets-plugin/blob/1.x/src/Commands/SecretsCommand.php)) that I'm guessing was used as a template to scaffold this plugin. 